### PR TITLE
Align bsdk with member constitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ Base Structure DK. The base structure proposed for the kernel beneath the Dk int
 
 **Documentation: [bsdk.drayker.org](https://bsdk.drayker.org)**. Published by GitHub Pages from [`docs/`](./docs), which is where the material for this component lives.
 
-Part of the Drayker ecosystem. Start at the [volunteers portal](https://drayker.org) for the map, or go straight to the [open functions](https://drayker.org/fn/) if you are looking for something to work on.
+Part of the Drayker ecosystem. Start at the [participation portal](https://drayker.org) for the map, or go straight to the [open functions](https://drayker.org/fn/) if you are looking for something to work on.
 
 Drayker is an open, primarily volunteer R&D initiative. [DFMP](https://dfmp.drayker.org) and [DAF](https://daf.drayker.org) describe proposed collaboration and governance architecture. The current founding-phase governance is documented in [`draykerdk/.github`](https://github.com/draykerdk/.github/blob/master/GOVERNANCE.md).


### PR DESCRIPTION
Carries the constitutional-alignment documentation updates for this component onto the public default branch. Part of the v1.4.2.7 book reconciliation round.